### PR TITLE
Challenge 12: GET request by comment_count query

### DIFF
--- a/__tests__/newsApi.test.js
+++ b/__tests__/newsApi.test.js
@@ -452,3 +452,66 @@ describe('CORE Task 11: GET request /api/articles?topic=mitch', () => {
     })
   });
 });
+
+describe('CORE Task 12: GET request /api/articles/:article_id', () => {
+  test('Status 200: GET request which responds with an object containing total count of all comments with the requested article_id when passed query string of comment_count', () => {
+    return request(app)
+    .get('/api/articles/1?comment_count')
+    .expect(200)
+    .then((res)=>{
+      const articleObj = res.body.article
+      expect(articleObj.article_id).toBe(1)
+      expect(articleObj).toMatchObject({
+          author: expect.any(String),
+          title: expect.any(String),
+          article_id: expect.any(Number),
+          topic: expect.any(String),
+          body: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String),
+          comment_count: expect.any(String)
+      })
+      expect(articleObj).toEqual({
+        author: 'butter_bridge',
+        title: 'Living in the shadow of a great man',
+        article_id: 1,
+        topic: 'mitch',
+        body: "I find this existence challenging",
+        created_at: '2020-07-09T20:11:00.000Z',
+        votes: 100,
+        article_img_url: 'https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700',
+        comment_count: '11'
+      })
+    })
+  });
+  test('Status 200: GET request which responds with an object of the requested article_id without the comment_count key if the query string is misspelt', () => {
+    return request(app)
+    .get('/api/articles/1?comment_cout')
+    .expect(200)
+    .then((res)=>{
+      const articleObj = res.body.article
+      expect(articleObj.article_id).toBe(1)
+      expect(articleObj).toMatchObject({
+          author: expect.any(String),
+          title: expect.any(String),
+          article_id: expect.any(Number),
+          body: expect.any(String),
+          topic: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String)
+      })
+      expect(articleObj).toEqual({
+        author: 'butter_bridge',
+        title: 'Living in the shadow of a great man',
+        article_id: 1,
+        topic: 'mitch',
+        body: "I find this existence challenging",
+        created_at: '2020-07-09T20:11:00.000Z',
+        votes: 100,
+        article_img_url: 'https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700',
+      })
+    })
+  });
+});

--- a/controllers/api.controller.js
+++ b/controllers/api.controller.js
@@ -20,7 +20,9 @@ exports.getAllEndpoints = (req,res, next)=>{
 
 exports.getArticleById = (req,res, next)=>{
     const {article_id} = req.params
-    selectArticleById(article_id).then((article)=>{
+    const {comment_count} =req.query
+    const commentKey = Object.keys(req.query)
+    selectArticleById(article_id, commentKey).then((article)=>{
         res.status(200).send({article})
     })
     .catch((err)=>{

--- a/endpoints.json
+++ b/endpoints.json
@@ -28,7 +28,7 @@
   },
   "GET /api/articles/:article_id": {
     "description": "Responds with an object from the requested article_id of an array",
-    "queries": ["article_id"],
+    "queries": ["article_id", "comment_count"],
     "exampleResponse" : {
       "articles": [
         {

--- a/models/api.model.js
+++ b/models/api.model.js
@@ -18,13 +18,25 @@ exports.selectAllEndpoints = ()=>{
     })
 }
 
-exports.selectArticleById = (article_id)=>{
+exports.selectArticleById = (article_id, commentKey)=>{
    return db.query('SELECT * FROM articles WHERE article_id = $1', [article_id])
    .then((data)=>{
     if (data.rows.length === 0){
         return Promise.reject({status: 404, msg: '404 Not Found'})
-    }
-    return data.rows[0]
+    } 
+    return data
+   })
+   .then((data)=>{
+       
+    if(commentKey.includes('comment_count')){
+        return db.query(`SELECT articles.author, articles.title, articles.article_id, articles.topic,articles.created_at,articles.body,articles.votes,articles.article_img_url, COUNT(comments.article_id) AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id WHERE articles.article_id = $1 GROUP BY articles.article_id;`, [article_id])
+       } else {
+        return data
+       }
+   
+    })
+   .then((response)=>{
+    return response.rows[0]
    })
 }
 


### PR DESCRIPTION
1. Added the request query with comment_count
2. Queried the database and changed field property to comment_count
3. No Error Handlers are handled in this case as empty or missspelt string outputs the article_id without the key of comment_count